### PR TITLE
feature(worker): halt worker on permissions error

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitializeTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitializeTask.java
@@ -110,7 +110,6 @@ class InitializeTask implements ITask {
                 LOG.error("Application initialize() threw exception: ", e);
             } else {
                 LOG.error("Caught exception: ", e);
-                throw new RuntimeException(e);
             }
             exception = e;
             // backoff if we encounter an exception.

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitializeTask.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/InitializeTask.java
@@ -110,6 +110,7 @@ class InitializeTask implements ITask {
                 LOG.error("Application initialize() threw exception: ", e);
             } else {
                 LOG.error("Caught exception: ", e);
+                throw new RuntimeException(e);
             }
             exception = e;
             // backoff if we encounter an exception.

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardConsumer.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -319,13 +320,14 @@ class ShardConsumer {
                 return TaskOutcome.SUCCESSFUL;
             }
             logTaskException(result);
+            throw result.getException();
         } catch (Exception e) {
+            if (e instanceof AmazonDynamoDBException) throw (AmazonDynamoDBException) e;
             throw new RuntimeException(e);
         } finally {
             // Setting future to null so we don't misinterpret task completion status in case of exceptions
             future = null;
         }
-        return TaskOutcome.FAILURE;
     }
 
     private void logTaskException(TaskResult taskResult) {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -489,12 +489,15 @@ public class Worker implements Runnable {
             shutdown();
         }
 
-        while (!shouldShutdown()) {
-            runProcessLoop();
+        try {
+            while (!shouldShutdown()) {
+                runProcessLoop();
+            }
         }
-
-        finalShutdown();
-        LOG.info("Worker loop is complete. Exiting from worker.");
+        finally {
+            finalShutdown();
+            LOG.info("Worker loop is complete. Exiting from worker.");
+        }
     }
 
     @VisibleForTesting

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -493,8 +493,7 @@ public class Worker implements Runnable {
             while (!shouldShutdown()) {
                 runProcessLoop();
             }
-        }
-        finally {
+        } finally {
             finalShutdown();
             LOG.info("Worker loop is complete. Exiting from worker.");
         }

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -468,7 +468,7 @@ public class Worker implements Runnable {
     /**
      * @return the leaseCoordinator
      */
-    KinesisClientLibLeaseCoordinator getLeaseCoordinator() {
+    public KinesisClientLibLeaseCoordinator getLeaseCoordinator() {
         return leaseCoordinator;
     }
 
@@ -1028,6 +1028,10 @@ public class Worker implements Runnable {
     private static ExecutorService getExecutorService() {
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("RecordProcessor-%04d").build();
         return new WorkerThreadPoolExecutor(threadFactory);
+    }
+
+    public ExecutorService returnExecutorService() {
+        return this.executorService;
     }
 
     private static <S, T> void setField(final S source, final String field, final Consumer<T> t, T value) {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -520,6 +521,8 @@ public class Worker implements Runnable {
 
             wlog.info("Sleeping ...");
             Thread.sleep(idleTimeInMilliseconds);
+        } catch (AmazonDynamoDBException e) {
+            throw e;
         } catch (Exception e) {
             if (causedByStreamRecordProcessingError(e))
                 throw new RuntimeException("Failing worker after irrecoverable failure: " + e.getMessage());

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java
@@ -468,7 +468,7 @@ public class Worker implements Runnable {
     /**
      * @return the leaseCoordinator
      */
-    public KinesisClientLibLeaseCoordinator getLeaseCoordinator() {
+    KinesisClientLibLeaseCoordinator getLeaseCoordinator() {
         return leaseCoordinator;
     }
 
@@ -1031,10 +1031,6 @@ public class Worker implements Runnable {
     private static ExecutorService getExecutorService() {
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("RecordProcessor-%04d").build();
         return new WorkerThreadPoolExecutor(threadFactory);
-    }
-
-    public ExecutorService returnExecutorService() {
-        return this.executorService;
     }
 
     private static <S, T> void setField(final S source, final String field, final Consumer<T> t, T value) {


### PR DESCRIPTION
*Issue #, if available:*
- Related to https://github.com/fivetran/engineering/issues/38536
- Should be merged in conjunction with https://github.com/fivetran/engineering/pull/43851

*Description of changes:*
- Have ShardConsumer#determineTaskOutcome preserve the `AmazonDynamoDBException` type when throwing exceptions.

- Force worker to enter Worker#finalShutdown when it encounters an `AmazonDynamoDBException` in Worker#runProcessLoop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
