### PR TITLE
fix(kinesis_proxy): fix AmazonKinesis client class name check

### DIFF
--- a/src/main/java/com/fivetran/external/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
+++ b/src/main/java/com/fivetran/external/com/amazonaws/services/kinesis/clientlibrary/proxies/KinesisProxy.java
@@ -217,7 +217,7 @@ public class KinesisProxy implements IKinesisProxyExtended {
         this.maxListShardsRetryAttempts = maxListShardsRetryAttempts;
 
         try {
-            if (Class.forName("com.fivetran.external.com.amazonaws.services.dynamodbv2.streamsadapter.AmazonDynamoDBStreamsAdapterClient")
+            if (Class.forName("com.amazonaws.services.dynamodbv2.streamsadapter.AmazonDynamoDBStreamsAdapterClient")
                     .isAssignableFrom(client.getClass())) {
                 isKinesisClient = false;
                 LOG.debug("Client is DynamoDb client, will use DescribeStream.");


### PR DESCRIPTION
Fix [#56457](https://github.com/fivetran/engineering/issues/56457)