### PR TITLE
fix(leases): robustify lease coordinator shutdown

### DIFF
--- a/src/main/java/com/fivetran/external/com/amazonaws/services/kinesis/leases/impl/LeaseCoordinator.java
+++ b/src/main/java/com/fivetran/external/com/amazonaws/services/kinesis/leases/impl/LeaseCoordinator.java
@@ -322,7 +322,7 @@ public class LeaseCoordinator<T extends Lease> {
      * Requests the cancellation of the lease taker.
      */
     public void stopLeaseTaker() {
-        takerFuture.cancel(false);
+        if (takerFuture != null) takerFuture.cancel(false);
 
     }
 


### PR DESCRIPTION
The old code would get you a `NullPointerException` if:
1. There was a failure in `Worker#initialize`
2. `Future#get` was called on the `Future<Boolean>` returned from `Worker#startGracefulShutdown`

This is because the `takerFuture` was not initialized. This PR will only attempt to `Future#cancel` the future if it exists. Otherwise, why try...